### PR TITLE
Update License field

### DIFF
--- a/maxscale.spec
+++ b/maxscale.spec
@@ -3,7 +3,7 @@ Version: 21.06.17
 Release: 6%{?dist}
 
 Summary: Database proxy for MariaDB Server
-License: GPLv2+
+License: (AFL-2.1 OR BSD-3-Clause) AND (BSD-3-Clause OR GPL-2.0-only) AND (MIT OR Apache-2.0) AND (MIT OR CC0-1.0) AND (WTFPL OR MIT) AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-3.0 AND CC-BY-4.0 AND CC0-1.0 AND GPL-2.0-or-later AND ISC AND LGPL-2.1-only AND MIT AND MPL-2.0 AND PSF-2.0 AND Unlicense AND Zlib AND blessing
 URL:     https://www.mariadb.com
 
 Source:  https://dlm.mariadb.com/MaxScale/%{version}/sourcetar/maxscale-%{version}-Source.tar.gz


### PR DESCRIPTION
The License field now contains correct SPDX license identifiers. The following documents the process with which the final license value was created. Notes in output are in square brackets.

MaxCtrl:

npx license-checker --production|grep licenses|sort|uniq │  ├─ licenses: 0BSD
│  ├─ licenses: Apache-2.0
│  ├─ licenses: BSD-2-Clause
│  ├─ licenses: BSD-3-Clause
│  ├─ licenses: CC-BY-4.0
│  ├─ licenses: Custom: ../LICENSE.TXT [this one is MaxCtrl itself] │  ├─ licenses: ISC
   ├─ licenses: MIT
│  ├─ licenses: MIT
│  ├─ licenses: MIT* [from cli-table@0.3.1, the license is in the README.md] │  ├─ licenses: (MIT OR CC0-1.0) [type-fest@0.21.3]

The license for maxctrl is then:

 GPL-2.0-or-later AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND
 BSD-3-Clause AND CC-BY-4.0 AND ISC AND MIT AND (MIT OR CC0-1.0)

MaxGUI:

browserify-rsa throws an error due to invalid URL but it's MIT: https://github.com/browserify/browserify-rsa/blob/master/LICENSE

element-matches has a link in the LICENSE file that points to the MIT license: https://jelmer.mit-license.org/

callsite only mentions that the license is MIT in the README.

npx license-checker --production|grep licenses|sort|uniq │  ├─ licenses: 0BSD
│  ├─ licenses: (AFL-2.1 OR BSD-3-Clause)
│  ├─ licenses: Apache-2.0
│  ├─ licenses: BSD* [this is glob-to-regexp which has a BSD-2-Clause license in the README] │  ├─ licenses: BSD-2-Clause
│  ├─ licenses: BSD-3-Clause
│  ├─ licenses: (BSD-3-Clause OR GPL-2.0)
│  ├─ licenses: CC0-1.0
│  ├─ licenses: CC-BY-3.0
│  ├─ licenses: CC-BY-4.0
│  ├─ licenses: Custom: https://github.com/FiloSottile/mkcert [This is BSD-3-Clause: https://github.com/FiloSottile/mkcert/blob/master/LICENSE] │  ├─ licenses: ISC
   ├─ licenses: MIT
│  ├─ licenses: MIT
│  ├─ licenses: MIT* [see notes]
│  ├─ licenses: (MIT AND BSD-3-Clause)
│  ├─ licenses: (MIT AND Zlib)
│  ├─ licenses: (MIT OR Apache-2.0)
│  ├─ licenses: (MIT OR CC0-1.0)
│  ├─ licenses: MPL-2.0
│  ├─ licenses: Python-2.0
│  ├─ licenses: Unlicense
│  ├─ licenses: (WTFPL OR MIT)

the license for the GUI is:

 GPL-2.0-or-later AND 0BSD AND (AFL-2.1 OR BSD-3-Clause) AND Apache-2.0
 AND BSD-2-Clause AND BSD-3-Clause AND (BSD-3-Clause OR GPL-2.0-only) AND
 CC0-1.0 AND CC-BY-3.0 AND CC-BY-4.0 AND ISC AND MIT AND Zlib AND (MIT
 OR Apache-2.0) AND (MIT OR CC0-1.0) AND MPL-2.0 AND PSF-2.0 AND
 Unlicense AND (WTFPL OR MIT)

MaxScale:

$ askalono crawl .
./connectors/cdc-connector/LICENSE
License: LGPL-2.1-only (original text) [only used for testing, removed in later releases] Score: 0.997
./query_classifier/qc_sqlite/sqlite-src-3110100/autoconf/tea/license.terms License: blessing (original text)
Score: 0.877
./query_classifier/qc_mysqlembedded/LICENSE
License: GPL-2.0-only (original text) [Not used with MaxScale by default, requires a custom build] Score: 0.986
./mariadb-connector-c/win/packaging/license.rtf
Error: Confidence threshold not high enough for any known license [Same as the LGPL-2.1-only license text but in rtf format] ./mariadb-connector-c/cmake/COPYING-CMAKE-SCRIPTS
License: BSD-3-Clause-HP (original text) [does not mention patents, seems like BSD-3-Clause] Score: 0.937
./mariadb-connector-c/COPYING.LIB
License: LGPL-2.1-only (original text)
Score: 0.998
./server/inih/LICENSE.txt
License: BSD-3-Clause-HP (original text) [does not mention patents, seems like BSD-3-Clause] Score: 0.898
./COPYRIGHT
Error: Confidence threshold not high enough for any known license [BUSL-1.1 license blurb] ./LICENSE-THIRDPARTY.TXT
Error: Confidence threshold not high enough for any known license [contains BSD-3-Clause, BSD-2-Clause, MIT, LGPL-2.1-only] ./jwt-cpp/LICENSE
License: MIT (original text)
Score: 1.000
./LICENSE.TXT
License: BUSL-1.1 (original text) [This is now GPL-2.0-or-later or perhaps (BUSL-1.1 OR GPL-2.0-or-later) ?] Score: 0.855

the license for the MaxScale core is (assuming it's GPL-2.0-or-later instead of BUSL-1.1):

 GPL-2.0-or-later AND blessing AND BSD-3-Clause AND BSD-2-Clause AND MIT
 AND LGPL-2.1-only

Putting all of these together, we get:

 (AFL-2.1 OR BSD-3-Clause) AND (BSD-3-Clause OR GPL-2.0-only) AND (MIT OR
 Apache-2.0) AND (MIT OR CC0-1.0) AND (WTFPL OR MIT) AND 0BSD AND
 Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-3.0 AND
 CC-BY-4.0 AND CC0-1.0 AND GPL-2.0-or-later AND ISC AND LGPL-2.1-only
 AND MIT AND MPL-2.0 AND PSF-2.0 AND Unlicense AND Zlib AND blessing