### PR TITLE
Add patch for inlining fonts

### DIFF
--- a/inline-fonts.patch
+++ b/inline-fonts.patch
@@ -1,0 +1,24 @@
+diff --git a/maxgui/vue.config.js b/maxgui/vue.config.js
+index e8cbe88ba49265205a126b625e1cad9c6bcaac29..c7471089a0502f4da702551b8a4f700e9c6f7267 100644
+--- a/maxgui/vue.config.js
++++ b/maxgui/vue.config.js
+@@ -28,6 +28,19 @@ module.exports = {
+         const types = ['vue-modules', 'vue', 'normal-modules', 'normal']
+         types.forEach(type => addStyleResource(config.module.rule('scss').oneOf(type)))
+         config.module.rule('js').exclude.add(/\.worker\.js$/)
++
++        // Clear existing rules for fonts to avoid conflicts
++        config.module.rules.delete('fonts')
++        config.module
++            .rule('fonts')
++            .test(/\.(woff2?|ttf)(\?.*)?$/i)
++            .use('url-loader')
++            .loader('url-loader')
++            .options({
++                limit: 10000000, // use a large value .i.e 10MB to inline everything
++            })
++            .end()
++
+         config.resolve.alias.set('@tests', path.resolve(__dirname, 'tests'))
+ 
+         config.resolve.alias.set(

--- a/maxscale.spec
+++ b/maxscale.spec
@@ -8,6 +8,7 @@ URL:     https://www.mariadb.com
 
 Source:  https://dlm.mariadb.com/MaxScale/%{version}/sourcetar/maxscale-%{version}-Source.tar.gz
 Patch0:  remove-dbfwfilter.patch
+Patch1:  inline-fonts.patch
 
 # Core MaxScale dependencies
 BuildRequires: cmake gcc-c++
@@ -52,6 +53,7 @@ by decoupling it from underlying database infrastructure.
 %setup -q -n maxscale-%{version}-Source
 
 %patch -P0 -p1
+%patch -P1 -p1
 
 %build
 # mariadb-connector-c and test_mxb_string cause warnings to be emitted during link-time optimization. The 3.2


### PR DESCRIPTION
This removes font files from the package and inlines them into the javascript. Given that the fonts aren't available in Fedora, inlining them seems like a reasonable way to solve the problem of font files in packages.